### PR TITLE
add: support for s3, glu_job  events in Slack notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,11 @@
   │    ├── server.py
   │    └── test_app.py
   └── monitoring
-       └── ...
+       ├── s3_event_rule.json
+       ├── s3_alert_lambda.py
+       ├── glue_job_event_rule.json
+       ├── glue_job_alert_lambda.py
+       └── glue_job_read_iam.json
   ```
 
 ### Summary

--- a/monitoring/glue_job_alert_lambda.py
+++ b/monitoring/glue_job_alert_lambda.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+import json
+import os
+import requests
+import boto3
+
+
+def lambda_handler(event, context):
+    webhook_url = os.environ.get('SLACK_WEBHOOK_URL')
+
+    if not webhook_url:
+        print('Slack Webhook URL not found')
+        return {
+            'statusCode': 400,
+            'body': json.dumps('Slack Webhook URL not found')
+        }
+
+    glue_job_name = event['detail']['jobName']
+    glue_job_run_id = event['detail']['jobRunId']
+    glue_job_state = event['detail']['state']
+
+    slack_message = {}
+    message_text = ''
+    attachments = ''
+    if glue_job_state == 'SUCCEEDED':
+        # message_text = f'Glue Job {glue_job_name} has succeeded!'
+        glue = boto3.client('glue')
+        response = glue.get_job_run(JobName=glue_job_name, RunId=glue_job_run_id)
+
+        execution_time = response['JobRun']['ExecutionTime']
+        hours, remainder = divmod(execution_time, 3600)
+        minutes, seconds = divmod(remainder, 60)
+
+        message_text = f"Glue Job {glue_job_name} has succeeded!"
+        attachments = f"Execution Time: {hours}h {minutes}m {seconds}s."
+
+    elif glue_job_state == 'FAILED':
+        message_text = f'Glue Job {glue_job_name} has failed.'
+    elif glue_job_state == 'TIMEOUT':
+        message_text = f'Glue Job {glue_job_name} has timed out.'
+    elif glue_job_state == 'STOPPED':
+        message_text = f'Glue Job {glue_job_name} has been stopped.'
+
+    slack_message['text'] = message_text
+    if attachments:
+        slack_message["attachments"] = [
+            {
+                "text": attachments
+            }
+        ]
+
+    response = requests.post(webhook_url, json=slack_message)
+
+    if response.status_code != 200:
+        print(f'Failed to send Slack message. Status Code: {response.status_code}, Reason: {response.text}')
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Slack message sent')
+    }

--- a/monitoring/glue_job_event_rule.json
+++ b/monitoring/glue_job_event_rule.json
@@ -1,0 +1,8 @@
+{
+    "source": ["aws.glue"],
+    "detail-type": ["Glue Job State Change"],
+    "detail": {
+      "state": ["SUCCEEDED", "FAILED", "TIMEOUT", "STOPPED"],
+      "jobName": ["de1_1_1st_preprocessing_script", "de1_1_2nd_preprocessing_script"]
+    }
+  }

--- a/monitoring/glue_job_read_iam.json
+++ b/monitoring/glue_job_read_iam.json
@@ -1,0 +1,12 @@
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"glue:GetJobRun"
+			],
+			"Resource": "arn:aws:glue:ap-northeast-2:<AWS_ID>:job/*"
+		}
+	]
+}

--- a/monitoring/s3_alert_lambda.py
+++ b/monitoring/s3_alert_lambda.py
@@ -1,0 +1,55 @@
+import json
+import requests
+import os
+
+def lambda_handler(event, context):
+    # Slack 웹훅 URL 환경 변수에서 가져오기
+    webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
+
+    if not webhook_url:
+        print("Slack Webhook URL not found")
+        return {
+            'statusCode': 400,
+            'body': json.dumps('Slack Webhook URL not found')
+        }
+
+    # 이벤트에서 필요한 정보 추출
+    bucket_name = event['detail']['bucket']['name']
+    object_key = event['detail']['object']['key']
+    detail_type = event.get('detail-type', '')
+
+    # Slack 메시지 초기 설정
+    slack_message = {"text": ""}
+
+    # detail-type 별로 메시지 내용 변경
+    if detail_type == "Object Created":
+        object_size = event['detail']['object']['size']
+        slack_message["text"] = "A new object has been created in S3"
+        slack_message["attachments"] = [
+            {
+                "text": f"Bucket Name: {bucket_name}\nObject Key: {object_key}\nObject Size: {object_size} bytes"
+            }
+        ]
+    elif detail_type == "Object Deleted":
+        slack_message["text"] = "An object has been deleted from S3"
+        slack_message["attachments"] = [
+            {
+                "text": f"Bucket Name: {bucket_name}\nObject Key: {object_key}"
+            }
+        ]
+    else:
+        slack_message["text"] = "Unknown S3 operation"
+
+    # Slack 웹훅을 통해 메시지 전송
+    response = requests.post(
+        webhook_url, data=json.dumps(slack_message),
+        headers={'Content-Type': 'application/json'}
+    )
+
+    if response.status_code != 200:
+        print(f"Failed to send slack message. Status Code: {response.status_code}, Reason: {response.text}")
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Slack message sent')
+    }

--- a/monitoring/s3_event_rule.json
+++ b/monitoring/s3_event_rule.json
@@ -1,0 +1,9 @@
+{
+  "source": ["aws.s3"],
+  "detail-type": ["Object Created", "Object Deleted"],
+  "detail": {
+    "bucket": {
+      "name": ["de-1-1"]
+    }
+  }
+}


### PR DESCRIPTION
## 변경 내용
- aws 이벤트를 감지해 slack으로 메시지를 전송합니다.
- ~_rule.json은 EventBridge에 사용할 rule 입니다.
- ~_lambda.py 는 event에 의해 트리거 되어 슬랙에 메시지를 보내는 람다 함수 코드입니다.
- glue_job_read_iam.json 은 glue 메타데이터를 받아오기 위해 람다 iam role에 추가해야 할 인라인 정책입니다.

